### PR TITLE
fix(mp): change content

### DIFF
--- a/apps/yuandao/App.vue
+++ b/apps/yuandao/App.vue
@@ -18,9 +18,11 @@ page {
   letter-spacing: 1rpx;
   padding-bottom: 20rpx;
 }
+
 button {
   width: 360rpx;
 }
+
 /* flex常用css */
 .flex {
   display: flex;
@@ -53,9 +55,11 @@ button {
 .fww {
   flex-wrap: wrap;
 }
+
 .shrink0 {
   flex-shrink: 0;
 }
+
 /* 颜色常用css */
 .mc {
   color: #8ba3c7;
@@ -68,9 +72,11 @@ button {
 .gbc {
   background-color: #07c160;
 }
+
 .gc {
   color: #60cf95;
 }
+
 .cr {
   color: rgb(253, 91, 91);
 }
@@ -123,9 +129,11 @@ button {
 .pd0 {
   padding: 0px !important;
 }
+
 .pd8 {
   padding: 8px;
 }
+
 .pd20 {
   padding: 20rpx;
 }
@@ -202,24 +210,31 @@ button {
 .mgr20 {
   margin-right: 20rpx;
 }
+
 .mgr10 {
   margin-right: 10rpx;
 }
+
 .mgla {
   margin-left: auto;
 }
+
 .h100 {
   height: 100rpx;
 }
+
 .h400 {
   height: 400rpx;
 }
+
 .w100 {
   width: 100%;
 }
+
 .w150 {
   width: 150rpx;
 }
+
 /* 字体常用CSS */
 .fwb {
   font-weight: bold;
@@ -268,9 +283,11 @@ button {
 .lh17 {
   line-height: 1.7;
 }
+
 .text-justify-none {
   text-justify: none;
 }
+
 /* 组件常用css */
 .br {
   border-radius: 4rpx;
@@ -331,12 +348,14 @@ button {
   padding: 20rpx 0;
   width: 100%;
 }
+
 .smallInput {
   margin: 10rpx 0;
   border-bottom: 1px solid #666;
   padding: 10rpx 0;
   width: 100%;
 }
+
 .icon {
   width: 80rpx;
   height: 80rpx;
@@ -346,10 +365,12 @@ button {
   width: 32rpx;
   height: 32rpx;
 }
+
 .likeIcon {
   width: 50rpx;
   height: 50rpx;
 }
+
 .area {
   margin: 100rpx auto;
   display: flex;
@@ -367,13 +388,16 @@ button {
   margin-bottom: 12rpx;
   font-size: 24rpx;
 }
+
 .bordereee {
   border: 1px solid #eee;
 }
+
 .smallImg {
   width: 140rpx;
   height: 140rpx;
 }
+
 .upload {
   font-size: 100rpx;
   height: 100rpx;
@@ -382,21 +406,26 @@ button {
   padding: 20rpx;
   color: #999;
 }
+
 .addIcon {
   margin-top: -10rpx;
 }
+
 .tab {
   border-bottom: 2px solid #8ba3c7;
   padding: 20rpx 0 18rpx;
 }
+
 .tabbar {
   margin: -40rpx -40rpx 0;
   border-bottom: 1px solid #ccc;
 }
+
 .plainButton {
   background: none;
   font-size: 32rpx;
 }
+
 .plainButton::after {
   border: none;
 }

--- a/apps/yuandao/pages/community/contribution.vue
+++ b/apps/yuandao/pages/community/contribution.vue
@@ -42,7 +42,7 @@
   </page-container>
   <view class="fs36 mg40">元岛的建设者们:</view>
   <view v-for="(item, index) in list" :key="index">
-    <view class="card mg40">
+    <view v-if="item.length" class="card mg40">
       <view class="fs36 mgb20">{{ item.user.name || "无昵称" }}</view>
       <view class="mgb20 flex aic fs28">
         <view>时间：</view>

--- a/apps/yuandao/pages/community/scholarship.vue
+++ b/apps/yuandao/pages/community/scholarship.vue
@@ -35,6 +35,7 @@ export default {
   data() {
     return {
       loading: false,
+      faq: false
     };
   },
   onLoad(e) {},

--- a/apps/yuandao/pages/course/question.vue
+++ b/apps/yuandao/pages/course/question.vue
@@ -18,7 +18,9 @@
         <view class="fs36">问题：</view>
         <textarea
           maxlength="200"
-          class="input h100"
+          auto-height="true"
+          class="input"
+          style="min-height: 100rpx;"
           name="question"
           placeholder="请详细描述你的问题，越详细越清晰将更可能被回复和采纳，无意义没有信息的问题无法回答，不被采纳。"
         ></textarea>
@@ -27,7 +29,8 @@
         <view class="fs36">你的答案：</view>
         <textarea
           maxlength="3000"
-          class="input h100"
+          auto-height="true"
+          class="input"
           name="answer"
           placeholder="分享你解决问题的经验来帮助他人"
         ></textarea>

--- a/apps/yuandao/pages/index/index.vue
+++ b/apps/yuandao/pages/index/index.vue
@@ -95,10 +95,10 @@
         <view class="shrink0">作业：</view>
         <view class="f1 c6">{{ lesson.homework || "请勿提交，等待更新" }}</view>
       </view>
-      <view class="fs28 mgb10 flex">
+      <view v-if="lesson.score" class="fs28 mgb10 flex">
         <view class="shrink0">奖励：</view>
         <view class="f1 fww">
-          <view v-if="lesson.score" class="flex jcsb">
+          <view  class="flex jcsb">
             <view class="flex aic mc">
               <view>等级+</view>
               <view> {{ lesson.level }}</view>
@@ -119,7 +119,7 @@
           <view class="c6" v-if="lesson.reward">{{ lesson.reward }}</view>
         </view>
       </view>
-      <view class="flex aic jcsa mgt40 mgb20">
+      <view class="flex aic jcsa mgt40 mgb10">
         <view
           @click="
             jump(

--- a/apps/yuandao/pages/manage/faqManage.vue
+++ b/apps/yuandao/pages/manage/faqManage.vue
@@ -5,7 +5,8 @@
         <view class="fs36">章节ID：</view>
         <textarea
           maxlength="200"
-          class="input h100"
+          auto-height="auto"
+          class="input"
           name="lessonId"
           placeholder="ID"
         ></textarea>
@@ -14,7 +15,8 @@
         <view class="fs36">问题：</view>
         <textarea
           maxlength="200"
-          class="input h100"
+          auto-height="true"
+          class="input"
           name="question"
           placeholder="你是如何遇到该问题的"
         ></textarea>
@@ -41,7 +43,8 @@
         <view class="fs36">回答：</view>
         <textarea
           maxlength="-1"
-          class="input h100"
+          auto-height="true"
+          class="input"
           name="answer"
           placeholder="回答"
         ></textarea>

--- a/apps/yuandao/pages/manage/teamManage.vue
+++ b/apps/yuandao/pages/manage/teamManage.vue
@@ -4,7 +4,7 @@
       <view class="fs36 mgb20 wba">小组名：{{ item.groupName }}</view>
       <view class="mgb10">类型：{{ item.type }}</view>
       <view class="mgb10 wba">介绍：{{ item.intro }}</view>
-      <view class="mgb10 wba">微信：{{ item.wx }}</view>
+      <view v-if="item.wx" class="mgb10 wba">微信：{{ item.wx }}</view>
       <view class="mgb10" v-if="item.checkActivity || item.checkLevel || item.checkAge || item.checkRegion">限制项：</view>
       <view class="flex aic fww">
         <view v-if="item.checkActivity" class="tag">要求活跃</view>

--- a/apps/yuandao/pages/team/form.vue
+++ b/apps/yuandao/pages/team/form.vue
@@ -47,7 +47,8 @@
         <view class="fs36">小组介绍：</view>
         <textarea
           maxlength="300"
-          class="input h100"
+          auto-height="true"
+          class="input"
           v-model="intro"
           name="intro"
           placeholder="20-300字"

--- a/apps/yuandao/pages/team/userTeams.vue
+++ b/apps/yuandao/pages/team/userTeams.vue
@@ -28,7 +28,7 @@
         <view v-if="item.team.wxNumber" class="mgb10"
           >联系方式：{{ item.team.wxNumber }}</view
         >
-        <view class="mgb10"> 小组群： </view>
+        <view v-if="item.team.wx" class="mgb10"> 小组群： </view>
         <image
           v-if="item.team.wx"
           :src="item.team.wx"

--- a/apps/yuandao/pages/user/notification.vue
+++ b/apps/yuandao/pages/user/notification.vue
@@ -1,5 +1,5 @@
 <template>
-  <view class="card mg40">
+  <view v-if="notifications.length" class="card mg40">
     <view v-for="(item, index) in notifications" :key="item.createdAt">
       <view v-if="!item.url" class="fs28 mgb20 mgt20"
         ><uni-dateformat

--- a/apps/yuandao/pages/user/profile.vue
+++ b/apps/yuandao/pages/user/profile.vue
@@ -49,8 +49,9 @@
         <view class="fs36">个性签名：</view>
         <textarea
           :maxlength="60"
+          auto-height="true"
           v-model="bio"
-          class="input h100"
+          class="input"
           name="bio"
           placeholder="60字内"
         ></textarea>
@@ -117,7 +118,6 @@ export default {
           this.loading = false;
         });
     },
-
     updateName: function (e) {
       let name = this.name;
 

--- a/apps/yuandao/uniCloud-aliyun/cloudfunctions/fun/functions/checkTeamForm.js
+++ b/apps/yuandao/uniCloud-aliyun/cloudfunctions/fun/functions/checkTeamForm.js
@@ -6,7 +6,7 @@ module.exports = async (args, db, userId, ctx) => {
       throw Error(form.data);
     }
     let res = await db.collection("team").orderBy("_id", "desc").limit(1).get();
-    let teamId = res.data[0]._id + 1;
+    let teamId = res.data.length ? res.data[0]._id + 1 : 1;
 
     let data = {
       ...team,

--- a/apps/yuandao/utils/cf.js
+++ b/apps/yuandao/utils/cf.js
@@ -65,7 +65,7 @@ export default async function (api, args, withLoading) {
 
     uni.showModal({
       title: "网络错误",
-      content: e.message,
+      content: e.message || "",
     });
     return false;
   }


### PR DESCRIPTION
细节优化
1. App.vue: css下面的空行补齐
2. 多个地方添加v-if判断有数据才显示提示文字和数据，不然提示文字空放那，感觉有点奇怪
3. community/scholarship.vue: faq变量没有在data的return中声明出来就直接使用，参见其他类似文件，补齐faq。
   但还是有个疑问，为啥!faq表示显示下面的补充信息
4. 多个地方将textarea加上自动增高，让文字靠线落地，而不是浮空，考虑到placeholder字体需要一定高度展示，部分使用min-height保证效果
5. 云函数checkTeamForm.js: 一开始，team表中没有数据，故查最后一个查不到，产生报错。添加这一情况的处理，判断查到最后一个就使用最后一个的_id + 1，不然就用1作为新id
6. utils/cf.js: 在一些特殊情况下，error.message可能为null或undefined，微信小程序要求content为string类型，故可能产生报错，没有按照预期提示网络错误，故用error.message || ""，保证在error.message为空时使用空字符串""代替，正确提示用户网络错误